### PR TITLE
Update dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,6 @@ buildscript {
         repositories {
             google()
             jcenter()
-            maven { url "https://dl.bintray.com/onfido/maven" }
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -60,6 +59,7 @@ android {
 repositories {
     // ref: https://www.baeldung.com/maven-local-repository
     mavenLocal()
+    mavenCentral()
     google()
     jcenter()
     maven {
@@ -70,7 +70,6 @@ repositories {
         // Android JSC is installed from npm
         url "$rootDir/../node_modules/jsc-android/dist"
     }
-    maven { url "https://dl.bintray.com/onfido/maven" }
 }
 
 dependencies {


### PR DESCRIPTION
Update because Bintray is no longer available https://blog.gradle.org/jcenter-shutdown.